### PR TITLE
Updated release to 15.03 and excluded the ca files from the repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 #
 #
 
-arc_frontend_release: "13.11"
+arc_frontend_release: "15.03"
 
 arc_frontend_packages:
  - nordugrid-arc-arex

--- a/templates/nordugrid.repo.j2
+++ b/templates/nordugrid.repo.j2
@@ -4,6 +4,7 @@ name=NorduGrid - $basearch - base
 baseurl=http://download.nordugrid.org/repos/{{ release }}/centos/$releasever/$basearch/base
 enabled=1
 gpgcheck=1
+exclude=ca_*
 gpgkey=http://download.nordugrid.org/RPM-GPG-KEY-nordugrid
 
 [nordugrid-updates]
@@ -11,6 +12,7 @@ name=NorduGrid - $basearch - updates
 baseurl=http://download.nordugrid.org/repos/{{ release }}/centos/$releasever/$basearch/updates
 enabled=1
 gpgcheck=1
+exclude=ca_*
 gpgkey=http://download.nordugrid.org/RPM-GPG-KEY-nordugrid
 
 [nordugrid-testing]


### PR DESCRIPTION
Using an old release is probably not sensible? A newer is in  epel anyways.

The CA-files should be taken from the egi repo, not from nordugrid.
